### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch:` input to the `build-and-publish` step listing both `master` and `2.x`, so the release job runs only on those branches.
- Mirrors the maintenance-branch pattern used in [`enonic/app-booster`](https://github.com/enonic/app-booster).
- Maintenance-branch hygiene only — `gradle.properties`, `enonic-docgen.yml`, and `docs/versions.json` intentionally left untouched on `2.x` (master-only per the reference repo).

## Test plan

- [ ] CI workflow `Gradle Build` runs on this PR and publishes only on the configured branches.