### PR TITLE
Upgrade to XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "2.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,12 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     id 'com.enonic.defaults' version '2.1.6'
-    id 'com.enonic.xp.base' version '3.6.2'
+    id 'com.enonic.xp.base'
 }
 
 dependencies {
-    compileOnly "com.enonic.xp:script-api:${xpVersion}"
-    compileOnly "com.enonic.xp:portal-api:${xpVersion}"
+    compileOnly xplibs.api.script
+    compileOnly xplibs.api.portal
 
     implementation ('net.sf.saxon:Saxon-HE:12.9') {
         exclude group: 'xml-apis'

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "2.x", "latest": true },
+    { "label": "next", "checkout": "master" }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=com.enonic.lib
 projectName=lib-xslt
-xpVersion=7.0.0
-version=2.2.0-SNAPSHOT
+xpVersion=8.0.0-B4
+version=3.0.0-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = projectName

--- a/src/main/java/com/enonic/lib/xslt/MapToXmlConverter.java
+++ b/src/main/java/com/enonic/lib/xslt/MapToXmlConverter.java
@@ -3,53 +3,70 @@ package com.enonic.lib.xslt;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 
-import com.enonic.xp.xml.DomBuilder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 final class MapToXmlConverter
 {
     public static Source toSource( final Map<String, Object> map )
     {
-        final DomBuilder builder = DomBuilder.create( "root" );
-        serializeMap( builder, map );
-        return new DOMSource( builder.getDocument() );
+        final Document document = newDocument();
+        final Element root = document.createElement( "root" );
+        document.appendChild( root );
+        serializeMap( document, root, map );
+        return new DOMSource( document );
     }
 
-    private static void serializeMap( final DomBuilder builder, final Map<?, ?> map )
+    private static void serializeMap( final Document document, final Element parent, final Map<?, ?> map )
     {
         for ( final Map.Entry<?, ?> item : map.entrySet() )
         {
-            builder.start( item.getKey().toString() );
-            serializeObject( builder, item.getValue() );
-            builder.end();
+            final Element child = document.createElement( item.getKey().toString() );
+            parent.appendChild( child );
+            serializeObject( document, child, item.getValue() );
         }
     }
 
-    private static void serializeObject( final DomBuilder builder, final Object value )
+    private static void serializeObject( final Document document, final Element parent, final Object value )
     {
         if ( value instanceof List )
         {
-            serializeList( builder, (List<?>) value );
+            serializeList( document, parent, (List<?>) value );
         }
         else if ( value instanceof Map )
         {
-            serializeMap( builder, (Map<?, ?>) value );
+            serializeMap( document, parent, (Map<?, ?>) value );
         }
         else
         {
-            builder.text( value.toString() );
+            parent.appendChild( document.createTextNode( value.toString() ) );
         }
     }
 
-    private static void serializeList( final DomBuilder builder, final List<?> list )
+    private static void serializeList( final Document document, final Element parent, final List<?> list )
     {
         for ( final Object item : list )
         {
-            builder.start( "item" );
-            serializeObject( builder, item );
-            builder.end();
+            final Element child = document.createElement( "item" );
+            parent.appendChild( child );
+            serializeObject( document, child, item );
+        }
+    }
+
+    private static Document newDocument()
+    {
+        try
+        {
+            return DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        }
+        catch ( final ParserConfigurationException e )
+        {
+            throw new IllegalStateException( e );
         }
     }
 }

--- a/src/main/java/com/enonic/lib/xslt/UriResolverImpl.java
+++ b/src/main/java/com/enonic/lib/xslt/UriResolverImpl.java
@@ -1,6 +1,6 @@
 package com.enonic.lib.xslt;
 
-import java.net.URL;
+import java.net.URI;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
@@ -27,8 +27,8 @@ final class UriResolverImpl
     {
         try
         {
-            final URL url = new URL( base );
-            return resolve( href, ResourceKey.from( url.getPath() ) );
+            final URI uri = URI.create( base );
+            return resolve( href, ResourceKey.from( uri.getSchemeSpecificPart() ) );
         }
         catch ( final Exception e )
         {
@@ -37,10 +37,15 @@ final class UriResolverImpl
     }
 
     private Source resolve( final String href, final ResourceKey base )
-        throws TransformerException
     {
         final ResourceKey resolvedResourceKey = base.resolve( "../" + href );
         final Resource resolvedResource = resourceService.getResource( resolvedResourceKey );
-        return resolvedResource.exists() ? new StreamSource( resolvedResource.getUrl().toString() ) : null;
+        if ( !resolvedResource.exists() )
+        {
+            return null;
+        }
+        final StreamSource source = new StreamSource( resolvedResource.openStream() );
+        source.setSystemId( resolvedResourceKey.toString() );
+        return source;
     }
 }

--- a/src/main/java/com/enonic/lib/xslt/function/AssetUrlFunction.java
+++ b/src/main/java/com/enonic/lib/xslt/function/AssetUrlFunction.java
@@ -5,7 +5,6 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.google.common.collect.Multimap;
 
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.portal.url.AssetUrlParams;
 import com.enonic.xp.portal.url.PortalUrlService;
 
@@ -30,7 +29,6 @@ public final class AssetUrlFunction
 
         final Multimap<String, String> arguments = params.getArgs();
 
-        urlParams.portalRequest( PortalRequestAccessor.get() ); // TODO: remove this, XP8 must resolve the request
         urlParams.path( singleValue( arguments, "_path" ) );
         urlParams.application( singleValue( arguments, "_application" ) );
         urlParams.type( singleValue( arguments, "_type" ) );

--- a/src/main/java/com/enonic/lib/xslt/function/AttachmentUrlFunction.java
+++ b/src/main/java/com/enonic/lib/xslt/function/AttachmentUrlFunction.java
@@ -5,7 +5,6 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.google.common.collect.Multimap;
 
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.portal.url.AttachmentUrlParams;
 import com.enonic.xp.portal.url.PortalUrlService;
 
@@ -30,7 +29,6 @@ public final class AttachmentUrlFunction
 
         final Multimap<String, String> arguments = params.getArgs();
 
-        urlParams.portalRequest( PortalRequestAccessor.get() ); // TODO: remove this, XP8 must resolve the request
         urlParams.type( singleValue( arguments, "_type" ) );
         urlParams.id( singleValue( arguments, "_id" ) );
         urlParams.path( singleValue( arguments, "_path" ) );

--- a/src/main/java/com/enonic/lib/xslt/function/ComponentUrlFunction.java
+++ b/src/main/java/com/enonic/lib/xslt/function/ComponentUrlFunction.java
@@ -5,7 +5,6 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.google.common.collect.Multimap;
 
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.portal.url.ComponentUrlParams;
 import com.enonic.xp.portal.url.PortalUrlService;
 
@@ -30,7 +29,6 @@ public final class ComponentUrlFunction
 
         final Multimap<String, String> arguments = params.getArgs();
 
-        urlParams.portalRequest( PortalRequestAccessor.get() ); // TODO: remove this, XP8 must resolve the request
         urlParams.type( singleValue( arguments, "_type" ) );
         urlParams.id( singleValue( arguments, "_id" ) );
         urlParams.path( singleValue( arguments, "_path" ) );

--- a/src/main/java/com/enonic/lib/xslt/function/ImageUrlFunction.java
+++ b/src/main/java/com/enonic/lib/xslt/function/ImageUrlFunction.java
@@ -5,7 +5,6 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.google.common.collect.Multimap;
 
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.portal.url.ImageUrlParams;
 import com.enonic.xp.portal.url.PortalUrlService;
 
@@ -30,7 +29,6 @@ public final class ImageUrlFunction
 
         final Multimap<String, String> arguments = params.getArgs();
 
-        urlParams.portalRequest( PortalRequestAccessor.get() ); // TODO: remove this, XP8 must resolve the request
         urlParams.type( singleValue( arguments, "_type" ) );
         urlParams.id( singleValue( arguments, "_id" ) );
         urlParams.path( singleValue( arguments, "_path" ) );

--- a/src/main/java/com/enonic/lib/xslt/function/PageUrlFunction.java
+++ b/src/main/java/com/enonic/lib/xslt/function/PageUrlFunction.java
@@ -5,7 +5,6 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.google.common.collect.Multimap;
 
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.portal.url.PageUrlParams;
 import com.enonic.xp.portal.url.PortalUrlService;
 
@@ -30,7 +29,6 @@ public final class PageUrlFunction
 
         final Multimap<String, String> arguments = params.getArgs();
 
-        urlParams.portalRequest( PortalRequestAccessor.get() ); // TODO: remove this, XP8 must resolve the request
         urlParams.type( singleValue( arguments, "_type" ) );
         urlParams.id( singleValue( arguments, "_id" ) );
         urlParams.path( singleValue( arguments, "_path" ) );

--- a/src/main/java/com/enonic/lib/xslt/function/ServiceUrlFunction.java
+++ b/src/main/java/com/enonic/lib/xslt/function/ServiceUrlFunction.java
@@ -5,7 +5,6 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.google.common.collect.Multimap;
 
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.portal.url.PortalUrlService;
 import com.enonic.xp.portal.url.ServiceUrlParams;
 
@@ -30,7 +29,6 @@ public final class ServiceUrlFunction
 
         final Multimap<String, String> arguments = params.getArgs();
 
-        urlParams.portalRequest( PortalRequestAccessor.get() ); // TODO: remove this, XP8 must resolve the request
         urlParams.type( singleValue( arguments, "_type" ) );
         urlParams.service( singleValue( arguments, "_service" ) );
         urlParams.application( singleValue( arguments, "_application" ) );

--- a/src/test/java/com/enonic/lib/xslt/MockViewFunctionService.java
+++ b/src/test/java/com/enonic/lib/xslt/MockViewFunctionService.java
@@ -1,5 +1,10 @@
 package com.enonic.lib.xslt;
 
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Multimap;
+
 import com.enonic.lib.xslt.function.ViewFunctionParams;
 import com.enonic.lib.xslt.function.ViewFunctionService;
 
@@ -9,6 +14,13 @@ public final class MockViewFunctionService
     @Override
     public Object execute( final ViewFunctionParams params )
     {
-        return params.getName() + "(" + params.getArgs().toString() + ")";
+        return params.getName() + "(" + sortedToString( params.getArgs() ) + ")";
+    }
+
+    private static String sortedToString( final Multimap<String, String> args )
+    {
+        return new TreeMap<>( args.asMap() ).entrySet().stream().
+            map( e -> e.getKey() + "=" + e.getValue() ).
+            collect( Collectors.joining( ", ", "{", "}" ) );
     }
 }

--- a/src/test/java/com/enonic/lib/xslt/XsltScriptTest.java
+++ b/src/test/java/com/enonic/lib/xslt/XsltScriptTest.java
@@ -1,11 +1,25 @@
 package com.enonic.lib.xslt;
 
-import org.junit.Assert;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import com.enonic.lib.xslt.function.ViewFunctionService;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.testing.ScriptRunnerSupport;
-import com.enonic.xp.xml.DomHelper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class XsltScriptTest
     extends ScriptRunnerSupport
@@ -26,7 +40,7 @@ public class XsltScriptTest
 
     private void assertXmlEquals( final String expectedXml, final String actualXml )
     {
-        Assert.assertEquals( cleanupXml( expectedXml ), cleanupXml( actualXml ) );
+        assertEquals( cleanupXml( expectedXml ), cleanupXml( actualXml ) );
     }
 
     public void assertXmlEquals( final ResourceKey resource, final String actualXml )
@@ -36,6 +50,40 @@ public class XsltScriptTest
 
     private String cleanupXml( final String xml )
     {
-        return DomHelper.serialize( DomHelper.parse( xml ) );
+        try
+        {
+            final Document document = DocumentBuilderFactory.newInstance().
+                newDocumentBuilder().
+                parse( new InputSource( new StringReader( xml ) ) );
+
+            stripWhitespaceTextNodes( document );
+
+            final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty( OutputKeys.INDENT, "no" );
+            final StringWriter writer = new StringWriter();
+            transformer.transform( new DOMSource( document ), new StreamResult( writer ) );
+            return writer.toString();
+        }
+        catch ( final Exception e )
+        {
+            throw new IllegalStateException( e );
+        }
+    }
+
+    private static void stripWhitespaceTextNodes( final Node node )
+    {
+        final NodeList children = node.getChildNodes();
+        for ( int i = children.getLength() - 1; i >= 0; i-- )
+        {
+            final Node child = children.item( i );
+            if ( child.getNodeType() == Node.TEXT_NODE && child.getNodeValue().trim().isEmpty() )
+            {
+                node.removeChild( child );
+            }
+            else
+            {
+                stripWhitespaceTextNodes( child );
+            }
+        }
     }
 }

--- a/src/test/java/com/enonic/lib/xslt/XsltServiceTest.java
+++ b/src/test/java/com/enonic/lib/xslt/XsltServiceTest.java
@@ -1,6 +1,6 @@
 package com.enonic.lib.xslt;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.testing.ScriptTestSupport;

--- a/src/test/resources/test/view/url-functions-result.xml
+++ b/src/test/resources/test/view/url-functions-result.xml
@@ -1,17 +1,17 @@
 <output>
-  <value>pageUrl({a=[1], _path=[some/path]})</value>
-  <value>pageUrl({a=[1], b=[2], _path=[some/path]})</value>
+  <value>pageUrl({_path=[some/path], a=[1]})</value>
+  <value>pageUrl({_path=[some/path], a=[1], b=[2]})</value>
   <value>imageUrl({_id=[123]})</value>
-  <value>imageUrl({b=[2], _name=[a]})</value>
+  <value>imageUrl({_name=[a], b=[2]})</value>
   <value>assetUrl({_path=[a]})</value>
-  <value>assetUrl({b=[2], _path=[a]})</value>
+  <value>assetUrl({_path=[a], b=[2]})</value>
   <value>attachmentUrl({_name=[myattachment.pdf]})</value>
-  <value>attachmentUrl({a=[1], _name=[myattachment.pdf]})</value>
-  <value>attachmentUrl({_name=[myattachment.pdf], _id=[123]})</value>
-  <value>attachmentUrl({_label=[source], _id=[123]})</value>
+  <value>attachmentUrl({_name=[myattachment.pdf], a=[1]})</value>
+  <value>attachmentUrl({_id=[123], _name=[myattachment.pdf]})</value>
+  <value>attachmentUrl({_id=[123], _label=[source]})</value>
   <value>serviceUrl({_service=[a]})</value>
-  <value>serviceUrl({b=[2], _service=[a]})</value>
+  <value>serviceUrl({_service=[a], b=[2]})</value>
   <value>componentUrl({_component=[a]})</value>
-  <value>componentUrl({b=[2], _component=[a]})</value>
-  <value>imagePlaceholder({width=[10], height=[10]})</value>
+  <value>componentUrl({_component=[a], b=[2]})</value>
+  <value>imagePlaceholder({height=[10], width=[10]})</value>
 </output>


### PR DESCRIPTION
## Summary

Upgrade `lib-xslt` from XP 7 to XP 8. The maintenance fork stays on XP 7 in branch `2.x` (created at the previous master HEAD `8cc3730`); see #140 for the parallel CI release-branch wiring.

### Build / dependency changes

- `gradle.properties`: `xpVersion=7.0.0` → `8.0.0-B4`; `version=2.2.0-SNAPSHOT` → `3.0.0-SNAPSHOT`.
- `settings.gradle`: apply `com.enonic.xp.settings` plugin `4.0.0-B1` (latest 4.x published to plugins.gradle.org).
- `build.gradle`: drop the version pin on `com.enonic.xp.base` (settings plugin supplies it); switch XP API coordinates to the `xplibs.api.script` / `xplibs.api.portal` catalog aliases. Keep `com.enonic.xp:testing` long-form per the upgrader skill.
- Bump the Gradle wrapper to `9.4.1`.

### XP 8 API churn handled in `src/main`

- `com.enonic.xp.xml.DomBuilder` is gone — `MapToXmlConverter` now uses `javax.xml.parsers.DocumentBuilderFactory` directly.
- `Resource.getUrl()` is gone — `UriResolverImpl` uses `openStream()` + sets the `ResourceKey` (`app:/path`) as the source's system identifier.
- `*UrlParams.portalRequest(PortalRequest)` is gone — calls dropped (the existing `// TODO: remove this, XP8 must resolve the request` comments flagged this exact migration).

### Tests

- JUnit 4 → 5: migrate `XsltServiceTest` (`org.junit.Test` → `org.junit.jupiter.api.Test`) and `XsltScriptTest` (drop `org.junit.Assert` for static `assertEquals`).
- `XsltScriptTest.cleanupXml(...)` no longer uses `com.enonic.xp.xml.DomHelper` (also removed in XP 8); it parses through `DocumentBuilderFactory`, strips whitespace-only text nodes, and serializes with `OutputKeys.INDENT="no"`.
- `MockViewFunctionService` now sorts the args map by key when stringifying. Without this the URL-functions test relies on the JVM-internal `HashMultimap` iteration order, which differs between Java 17 (passes pre-migration) and Java 21+/25 (fails). Expected XML in `url-functions-result.xml` updated to the sorted form.

### Workflow + docs (master only)

- `.github/workflows/enonic-gradle.yml`: add `releaseBranch: master / 2.x` to scope the publish step.
- `.github/workflows/enonic-docgen.yml`: also build docs on pushes to `2.x`.
- `docs/versions.json`: `stable` → `2.x` (latest), `next` → `master` — mirrors the app-booster pattern.

## Verification

- `./gradlew clean build` is green on Java 25 with the 9.4.1 wrapper (full check including tests + JaCoCo report).
- `2.x` branch was created at master HEAD `8cc3730bc614ed3c350b1befa5c4e841468aed4a` *before* any of these edits, so it preserves `xpVersion=7.0.0` / `version=2.2.0-SNAPSHOT` for the XP 7 maintenance fork. Confirmed via `gh api repos/enonic/lib-xslt/contents/gradle.properties?ref=2.x`.

## Test plan

- [ ] CI `Gradle Build` runs and publishes the new `3.0.0-SNAPSHOT` artifact.
- [ ] Smoke against an XP 8 sandbox (out of scope here — sandbox is ephemeral on the migration runner).