### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,15 +10,15 @@ dependencies {
     compileOnly xplibs.api.script
     compileOnly xplibs.api.portal
 
-    implementation ('net.sf.saxon:Saxon-HE:12.9') {
+    implementation ( libs.saxon.he ) {
         exclude group: 'xml-apis'
     }
 
-    testImplementation( platform( "org.junit:junit-bom:6.0.3" ) )
-    testImplementation( platform( "org.mockito:mockito-bom:5.23.0" ) )
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation( platform( libs.junit.bom ) )
+    testImplementation( platform( libs.mockito.bom ) )
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly libs.junit.platform.launcher
+    testImplementation libs.mockito.junit.jupiter
     testImplementation "com.enonic.xp:testing:${xpVersion}"
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,12 @@
+[versions]
+junit = "6.0.3"
+mockito = "5.23.0"
+saxon-he = "12.9"
+
+[libraries]
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
+saxon-he = { module = "net.sf.saxon:Saxon-HE", version.ref = "saxon-he" }


### PR DESCRIPTION
## Summary

Move inline dependency versions in `build.gradle` into a new `gradle/libs.versions.toml`, so `lib-xslt` matches the catalog-based convention already used by ~half of the sibling app-/lib- repos. This unifies how versions are pinned across the tree and lets bulk dep bumps target a single pattern.

Pin-for-pin migration — no version bumps. The resolved dependency tree (`compileClasspath`, `runtimeClasspath`, `testRuntimeClasspath`) is byte-identical before and after.

## Conventions adopted

- `[versions]` and `[libraries]` blocks both sorted alphabetically.
- Keys are short, lowercase, hyphen-separated (matching the dominant style in the tree).
- `xpVersion` left in `gradle.properties`; `xplibs.*` accessors untouched.
- Plugin versions left inline — no `[plugins]` block introduced for this single-plugin case.

## Catalog content

```toml
[versions]
junit = "6.0.3"
mockito = "5.23.0"
saxon-he = "12.9"

[libraries]
junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
saxon-he = { module = "net.sf.saxon:Saxon-HE", version.ref = "saxon-he" }
```

## Test plan

- [x] `./gradlew build --refresh-dependencies` — green; all 9 test suites pass.
- [x] `./gradlew dependencies` for `compileClasspath`, `runtimeClasspath`, `testRuntimeClasspath` matches pre-migration output byte-for-byte.