### PR TITLE
Add @enonic-types/lib-xslt types package #151

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             2.x

--- a/build.gradle
+++ b/build.gradle
@@ -43,3 +43,15 @@ repositories {
     mavenCentral()
     xp.enonicRepo('dev')
 }
+
+// Assemble the @enonic-types/lib-xslt npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,14 @@
+import type { ResourceKey } from "@enonic-types/core";
+
+declare module "/lib/xslt" {
+    /**
+     * Renders a view using XSLT. The model is automatically transformed to XML.
+     *
+     * @param view Location of the view. Use `resolve(...)` to resolve a view.
+     * @param model Model that is passed to the view.
+     * @returns The rendered output.
+     */
+    export function render(view: ResourceKey, model: Record<string, unknown>): string;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-xslt",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP XSLT library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-xslt",
+    "xslt",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-xslt#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-xslt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-xslt/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
Publishes a TypeScript types package for lib-xslt so consumers get typed access to `/lib/xslt` instead of falling back to `@ts-expect-error` on the import (e.g. `app-sitemap-xml/src/main/resources/cms/controllers/sitemap/sitemap.ts:16` today).

## Changes
- `types/index.d.ts` — ambient module declaration for `/lib/xslt` (`render(view, model)`), signature verified against `src/main/resources/lib/xslt.js` and the underlying `XsltService`/`XsltProcessor` Java beans.
- `types/package.json` — `@enonic-types/lib-xslt` manifest (version substituted at build time).
- `build.gradle` — `assembleTypes` Copy task builds `build/types` with `project.version` injected; `jar.dependsOn assembleTypes` (mirrors lib-mustache's pattern; no node build needed for a pure-JS lib).
- `enonic-gradle.yml` — `npmPublish: true` on build-and-publish + `id-token: write` for OIDC trusted publishing.

Verified locally: `./gradlew build` green; `build/types/` contains `index.d.ts` + `package.json` with the substituted version (`3.1.0-SNAPSHOT`).

**Note:** the first publish of a brand-new `@enonic-types/lib-xslt` needs the npm trusted-publisher / package access configured org-side. Depends on enonic/release-tools#71 (publish-only npmPublish) — merged.

Closes #151