### PR TITLE
Align docs to standard layout #153

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "3.x"
       - "2.x"
     paths:
       - 'docs/**'

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,13 +1,15 @@
 = XSLT Library
 
-image::https://img.shields.io/badge/xp-7.+-blue.svg[role="right"]
+image::https://img.shields.io/badge/xp-8.+-blue.svg[role="right"]
+
+NOTE: Versions 3.x target XP 8+.
 
 This library provides basic XSLT rendering functionality to create pages and parts using XSLT as the templating language.
 
 [source,groovy]
 ----
 dependencies {
-  include 'com.enonic.lib:lib-xslt:2.+'
+  include 'com.enonic.lib:lib-xslt:3.+'
 }
 ----
 
@@ -59,8 +61,3 @@ This will create a document, based on the template in the view, and the content 
 
 * `view` (_object_) Location of the view. Use resolve(..) to resolve a view.
 * `model` (_object_) Model that is passed to the view.
-
-
-== Compatibility
-
-If you are upgrading from one of the early versions of the lib (before 2.0.0) to 2.0.0 or higher, make sure you are using correct reference: `/lib/xslt` (not `/lib/xp/xslt` or `/site/lib/xp/xslt`).

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-    { "label": "stable", "checkout": "2.x", "latest": true },
-    { "label": "next", "checkout": "master" }
+    { "label": "stable", "checkout": "3.x", "latest": true },
+    { "label": "2.x", "checkout": "2.x" }
   ]
 }


### PR DESCRIPTION
Aligns `docs/` to the same layout used by [enonic/lib-cors](https://github.com/enonic/lib-cors/tree/master/docs) and drops version-history clutter from the current (XP 8) docs.

## Changes

- **`docs/index.adoc`**
  - Add `NOTE: Versions 3.x target XP 8+.` near the top.
  - Bump the XP compatibility badge to `xp-8.+` and the example dependency to `com.enonic.lib:lib-xslt:3.+` to match the 3.x line.
  - Drop the "Compatibility" section on migrating from pre-2.0.0 `/lib/xp/xslt` require paths — pure legacy clutter for XP 8 readers of the current version.
- **`docs/versions.json`**: advertise `3.x` as stable (`latest: true`) and `2.x` as the older line; drop the `next=master` entry that lib-cors doesn't use.
- **`.github/workflows/enonic-docgen.yml`**: also trigger on `3.x` pushes so the new stable branch regenerates docs (master + every branch in versions.json).

## Follow-up

- The clutter cleanup will be cherry-picked onto the `3.x` stable branch in a separate PR.
- The `2.x` branch is intentionally left untouched.

Closes #153