### PR TITLE
Align docs to standard layout #153

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - "master"
-      - "2.x"
       - "3.x"
+      - "2.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -2,6 +2,8 @@
 
 image::https://img.shields.io/badge/xp-8.+-blue.svg[role="right"]
 
+NOTE: Versions 3.x target XP 8+.
+
 This library provides basic XSLT rendering functionality to create pages and parts using XSLT as the templating language.
 
 [source,groovy]
@@ -59,8 +61,3 @@ This will create a document, based on the template in the view, and the content 
 
 * `view` (_object_) Location of the view. Use resolve(..) to resolve a view.
 * `model` (_object_) Model that is passed to the view.
-
-
-== Compatibility
-
-If you are upgrading from one of the early versions of the lib (before 2.0.0) to 2.0.0 or higher, make sure you are using correct reference: `/lib/xslt` (not `/lib/xp/xslt` or `/site/lib/xp/xslt`).

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-    { "label": "stable", "checkout": "2.x", "latest": true },
-    { "label": "next", "checkout": "master" }
+    { "label": "stable", "checkout": "3.x", "latest": true },
+    { "label": "2.x", "checkout": "2.x" }
   ]
 }


### PR DESCRIPTION
Backport of #154 to the `3.x` stable branch.

## Changes

- **`docs/index.adoc`**
  - Add `NOTE: Versions 3.x target XP 8+.` near the top.
  - Drop the "Compatibility" section on migrating from pre-2.0.0 `/lib/xp/xslt` require paths — pure legacy clutter for XP 8 readers of the current version.
  - (The XP badge and dependency version are already correct on this branch.)
- **`docs/versions.json`**: advertise `3.x` as stable (`latest: true`) and `2.x` as the older line; drop the obsolete `next=master` entry.
- **`.github/workflows/enonic-docgen.yml`**: re-order the branch list to match `master` (`master`, `3.x`, `2.x`). `3.x` was already present; no functional change.

## Notes

The `2.x` branch is intentionally left untouched — its docs and workflow are frozen.

Refs #153